### PR TITLE
Implementations for ConstaintInfo and StateInfo

### DIFF
--- a/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
+++ b/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
@@ -287,6 +287,15 @@ ANALYZER_OPTION(bool, DisplayCTUProgress, "display-ctu-progress",
                 "the analyzer's progress related to ctu.",
                 false)
 
+ANALYZER_OPTION(bool, ShouldDumpConstraintInfo, "dump-constraint-info",
+                "Returns true if contraint information should be included in "
+                "the plist ouput for each controlflow and event pieces.", false)
+
+ANALYZER_OPTION(bool, ShouldDumpStateInfo, "dump-state-info",
+                "Returns true if ProgramState information should be included "
+                "in the plist ouput for each controlflow and event pieces.",
+                false)
+
 //===----------------------------------------------------------------------===//
 // Unsinged analyzer options.
 //===----------------------------------------------------------------------===//

--- a/include/clang/StaticAnalyzer/Core/BugReporter/InternalInfo.h
+++ b/include/clang/StaticAnalyzer/Core/BugReporter/InternalInfo.h
@@ -1,0 +1,160 @@
+//===- InternalInfo.h -------------------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the InternalInfo interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_STATICANALYZER_CORE_BUGREPORTER_INTERNALINFO_H
+#define LLVM_CLANG_STATICANALYZER_CORE_BUGREPORTER_INTERNALINFO_H
+
+#include "clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace clang {
+
+namespace markup {
+
+using FIDMap = llvm::DenseMap<FileID, unsigned>;
+
+} // end of namespace markup
+
+namespace ento {
+
+/// Abstract interface for storing debug and various other information.
+class InternalInfo : public llvm::FoldingSetNode {
+public:
+  /// All descendants must add a new kind.
+  enum Kind { None, Constraint, State };
+
+private:
+  const Kind kind;
+
+protected:
+  InternalInfo(Kind kind) : kind(kind) {}
+
+public:
+  virtual ~InternalInfo() = default;
+
+  Kind getKind() const { return kind; }
+
+  /// All descendants must override this method and return with their kind.
+  static constexpr Kind getStaticKind() { return None; }
+
+  static bool isSameKind(const InternalInfo &Info) {
+    return Info.getKind() == getStaticKind();
+  }
+
+  /// Profile - Used to profile the contents of this object for inclusion in a
+  /// FoldingSet.
+  void Profile(llvm::FoldingSetNodeID &ID) const {
+    ID.AddInteger(static_cast<int>(kind));
+  }
+
+  template <typename T> T *getAs() {
+    return T::isSameKind(*this) ? static_cast<T *>(this) : nullptr;
+  }
+
+  virtual void addFIDs(markup::FIDMap &FIDs, SmallVectorImpl<FileID> &V,
+                       const SourceManager &SM) const = 0;
+
+  virtual void printPlist(llvm::raw_ostream &Out, const SourceManager &SM,
+                          const markup::FIDMap &FM, unsigned Indent) const = 0;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump(const SourceManager &SM) const {
+    dumpToStream(llvm::errs(), SM);
+  }
+  LLVM_DUMP_METHOD virtual void dumpToStream(llvm::raw_ostream &Out,
+                                             const SourceManager &SM) const = 0;
+#endif
+};
+
+/// A wrapper around llvm::FoldingSet<InternalInfo>.
+class InternalInfoMap {
+  using InternalInfoMapImpl = llvm::FoldingSet<InternalInfo>;
+
+public:
+  using iterator = InternalInfoMapImpl::iterator;
+  using const_iterator = InternalInfoMapImpl::const_iterator;
+  using value_type = InternalInfo;
+
+private:
+  llvm::FoldingSet<InternalInfo> Set;
+
+public:
+  ~InternalInfoMap() {
+    for (const auto &E : Set)
+      delete &E;
+  }
+
+  bool empty() const { return Set.empty(); }
+  iterator begin() { return Set.begin(); }
+  const_iterator begin() const { return Set.begin(); }
+  iterator end() { return Set.end(); }
+  const_iterator end() const { return Set.end(); }
+
+  /// Get an InternalInfo object from the map. If the map doesn't contain an
+  /// object of type \p T, it inserts it first.
+  ///
+  /// \param T - Descendant of InternalInfo.
+  template <typename T, typename... Args> T &getOrInsert(Args &&... CtorArgs) {
+    llvm::FoldingSetNodeID ID;
+    ID.AddInteger(static_cast<int>(T::getStaticKind()));
+    void *Pos;
+
+    InternalInfo *Val = Set.FindNodeOrInsertPos(ID, Pos);
+    if (!Val) {
+      Val = new T(std::forward<Args>(CtorArgs)...);
+      Set.InsertNode(Val, Pos);
+    }
+
+    return static_cast<T &>(*Val);
+  }
+
+  /// Get an InternalInfo object from the map. Assert if it's not in the map.
+  ///
+  /// \param T - Descendant of InternalInfo.
+  template <typename T> T &get() {
+    llvm::FoldingSetNodeID ID;
+    ID.AddInteger(static_cast<int>(T::getStaticKind()));
+    void *Pos;
+
+    InternalInfo *Val = Set.FindNodeOrInsertPos(ID, Pos);
+    assert(Val && "The map doesn't contain the specified InternalInfo object!");
+
+    return static_cast<T &>(*Val);
+  }
+
+  template <typename T> bool isEnabled() {
+    llvm::FoldingSetNodeID ID;
+    ID.AddInteger(static_cast<int>(T::getStaticKind()));
+    void *Pos;
+
+    InternalInfo *Val = Set.FindNodeOrInsertPos(ID, Pos);
+    return Val;
+  }
+
+  void addFIDs(markup::FIDMap &FIDs, SmallVectorImpl<FileID> &V,
+               const SourceManager &SM) const;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump(const SourceManager &SM) const {
+    dumpToStream(llvm::errs(), SM);
+  }
+  LLVM_DUMP_METHOD void dumpToStream(llvm::raw_ostream &Out,
+                                     const SourceManager &SM) const;
+#endif
+};
+
+} // namespace ento
+} // namespace clang
+
+#endif // LLVM_CLANG_STATICANALYZER_CORE_BUGREPORTER_INTERNALINFO_H

--- a/include/clang/StaticAnalyzer/Core/BugReporter/PathDiagnostic.h
+++ b/include/clang/StaticAnalyzer/Core/BugReporter/PathDiagnostic.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
+#include "InternalInfo.h"
 #include <cassert>
 #include <deque>
 #include <iterator>
@@ -380,12 +381,16 @@ private:
   bool LastInMainSourceFile = false;
 
   /// A constant string that can be used to tag the PathDiagnosticPiece,
-  /// typically with the identification of the creator.  The actual pointer
+  /// typically with the identification of the creator. The actual pointer
   /// value is meant to be an identifier; the string itself is useful for
   /// debugging.
   StringRef Tag;
 
   std::vector<SourceRange> ranges;
+
+public:
+  /// Internal info, that can optionally be dumped.
+  InternalInfoMap InternalInfos;
 
 protected:
   PathDiagnosticPiece(StringRef s, Kind k, DisplayHint hint = Below);
@@ -456,6 +461,10 @@ public:
     flattenTo(Result, Result, ShouldFlattenMacros);
     return Result;
   }
+
+  iterator erase(const_iterator Pos);
+
+  iterator erase(const_iterator first, const_iterator last) = delete;
 
   void dump() const;
 };

--- a/lib/StaticAnalyzer/Core/CMakeLists.txt
+++ b/lib/StaticAnalyzer/Core/CMakeLists.txt
@@ -26,6 +26,7 @@ add_clang_library(clangStaticAnalyzerCore
   ExprEngineObjC.cpp
   FunctionSummary.cpp
   HTMLDiagnostics.cpp
+  InternalInfo.cpp
   IssueHash.cpp
   LoopUnrolling.cpp
   LoopWidening.cpp

--- a/lib/StaticAnalyzer/Core/InternalInfo.cpp
+++ b/lib/StaticAnalyzer/Core/InternalInfo.cpp
@@ -1,0 +1,346 @@
+//===- InternalInfo.cpp -----------------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines implementations of InternalInfo.
+//
+//===----------------------------------------------------------------------===//
+
+#include "InternalInfoImplementations.h"
+#include "clang/Basic/PlistSupport.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/RangedConstraintManager.h"
+
+using namespace clang;
+using namespace ento;
+using namespace markup;
+
+//===----------------------------------------------------------------------===//
+// InternalInfoMap methods.
+//===----------------------------------------------------------------------===//
+
+void InternalInfoMap::addFIDs(FIDMap &FIDs, SmallVectorImpl<FileID> &V,
+                              const SourceManager &SM) const {
+  for (auto &E : Set)
+    E.addFIDs(FIDs, V, SM);
+}
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void
+InternalInfoMap::dumpToStream(llvm::raw_ostream &Out,
+                              const SourceManager &SM) const {
+  for (auto &E : Set) {
+    E.dumpToStream(Out, SM);
+    Out << '\n';
+  }
+}
+#endif
+
+//===----------------------------------------------------------------------===//
+// ConstraintInfo methods.
+//===----------------------------------------------------------------------===//
+
+void ConstraintInfo::ConstraintEntry::update(const ConstraintEntry &Other) {
+  if (Statement.empty()) {
+    Statement = Other.Statement;
+  }
+  if (Symbol.empty()) {
+    Symbol = Other.Symbol;
+  }
+  if (Constraint.empty()) {
+    Constraint = Other.Constraint;
+  }
+}
+
+void ConstraintInfo::copyContents(const ConstraintInfo &Other) {
+  for (const ConstraintMapTy::value_type &Entry : Other.ConstraintMap) {
+    ConstraintMap.insert(Entry);
+  }
+}
+
+namespace {
+
+class GetAllConcreteValues : public StoreManager::BindingsHandler {
+  using ConstraintMapTy = ConstraintInfo::ConstraintMapTy;
+  using ConstraintEntry = ConstraintInfo::ConstraintEntry;
+
+  ConstraintMapTy &ConstraintMap;
+  ProgramStateRef State;
+
+public:
+  GetAllConcreteValues(ConstraintMapTy &C, ProgramStateRef State)
+      : ConstraintMap(C), State(State) {}
+
+  virtual bool HandleBinding(StoreManager &SMgr, Store Store,
+                             const MemRegion *R, SVal V) {
+    addToMapIfConcreteInt<loc::ConcreteInt>(R, V);
+    addToMapIfConcreteInt<nonloc::ConcreteInt>(R, V);
+    return true;
+  }
+
+private:
+  template <class LocOrNonlocConcreteInt>
+  void addToMapIfConcreteInt(const MemRegion *R, SVal V) {
+    static_assert(
+        std::is_same<LocOrNonlocConcreteInt, loc::ConcreteInt>::value ||
+            std::is_same<LocOrNonlocConcreteInt, nonloc::ConcreteInt>::value,
+        "Template parameter may only be a loc::ConcreteInt "
+        "or nonloc::ConcreteInt!");
+
+    const auto &C = V.getAs<LocOrNonlocConcreteInt>();
+    if (!C)
+      return;
+
+    if (R->sourceRange().isInvalid())
+      return;
+
+    ConstraintEntry CEntry;
+
+    llvm::raw_string_ostream StmtOS(CEntry.Statement);
+    llvm::raw_string_ostream ConstraintOS(CEntry.Constraint);
+
+    R->dumpToStream(StmtOS);
+    ConstraintOS << " == ";
+
+    printValueOfConcreteInt(*C, ConstraintOS);
+    ConstraintOS.flush();
+    StmtOS.flush();
+
+    ConstraintMap[R->sourceRange()].update(CEntry);
+  }
+
+  void printValueOfConcreteInt(loc::ConcreteInt C, llvm::raw_ostream &Out) {
+    if (C.isZeroConstant())
+      Out << "nullptr";
+    else
+      Out.write_hex(C.getValue().getExtValue());
+  }
+
+  void printValueOfConcreteInt(nonloc::ConcreteInt C, llvm::raw_ostream &Out) {
+    Out << C.getValue();
+  }
+};
+
+} // end of anonymous namespace
+
+void ConstraintInfo::AddEnvironmentConstraintsToMap(ProgramStateRef State) {
+  const Environment &Env = State->getEnvironment();
+
+  for (const std::pair<EnvironmentEntry, SVal> &Entry : Env) {
+
+    const Stmt *EntryStmt = Entry.first.getStmt();
+    if (EntryStmt->getSourceRange().isInvalid())
+      continue;
+
+    const SVal &EntryVal = Entry.second;
+    ConstraintEntry CEntry;
+
+    llvm::raw_string_ostream StmtOS(CEntry.Statement);
+
+    EntryStmt->printPretty(
+        StmtOS, /*PrinterHelper*/ nullptr,
+        PrintingPolicy(State->getStateManager().getContext().getLangOpts()));
+    StmtOS.flush();
+
+    // If this entry is a binary operator, like 'i < 0' or 'j + 10'.
+    if (const auto &BinOp = dyn_cast_or_null<BinaryOperator>(EntryStmt)) {
+
+      // If we know the value of the binary expression, add it to the map.
+      const auto &Concr = EntryVal.getAs<nonloc::ConcreteInt>();
+      if (!Concr)
+        continue;
+
+      llvm::raw_string_ostream ConstraintOS(CEntry.Constraint);
+
+      ConstraintOS << " == ";
+      // If this is a binary operator that returns with a boolean value
+      // (<, >, ==, etc).
+      if (BinOp->getType()->isBooleanType()) {
+        if (Concr->getValue().isNullValue())
+          ConstraintOS << "false";
+        else
+          ConstraintOS << "true";
+      } else {
+        // This is a binary operator that returns with a non-boolean value
+        // (+, -, <<, etc).
+        ConstraintOS << Concr->getValue().getExtValue();
+      }
+      ConstraintOS.flush();
+
+      // This entry tells us that the Entry was assigned a symbol like 'reg_$0'.
+    } else if (const SymbolRef Sym = EntryVal.getAsSymbol()) {
+      llvm::raw_string_ostream SymbolOS(CEntry.Symbol);
+
+      Sym->dumpToStream(SymbolOS);
+
+      SymbolOS.flush();
+
+      // Any other entries are of no use to us, discard them.
+    } else {
+      continue;
+    }
+
+    ConstraintMap[EntryStmt->getSourceRange()].update(CEntry);
+  }
+}
+
+void ConstraintInfo::AddConstraintManagerConstraintsToMap(
+    ProgramStateRef State) {
+
+  // Adding constraints from RangeConstraintManager.
+  const ConstraintRangeTy &RangeConstraints = State->get<ConstraintRange>();
+  for (const std::pair<SymbolRef, RangeSet> &Pair : RangeConstraints) {
+
+    const MemRegion *OrigR = Pair.first->getOriginRegion();
+    if (!OrigR)
+      continue;
+
+    if (OrigR->sourceRange().isInvalid())
+      continue;
+
+    ConstraintEntry CEntry;
+
+    llvm::raw_string_ostream ConstraintOS(CEntry.Constraint);
+
+    if (CEntry.Constraint.empty()) {
+      llvm::raw_string_ostream SymbolOS(CEntry.Symbol);
+      Pair.first->dumpToStream(SymbolOS);
+    }
+    ConstraintOS << " in ";
+    Pair.second.print(ConstraintOS);
+    ConstraintOS.flush();
+
+    ConstraintMap[OrigR->sourceRange()].update(CEntry);
+  }
+}
+
+void ConstraintInfo::addConstraintsFromState(ProgramStateRef State) {
+  // Collecting constraints and symbols from the environment (such as i < 0).
+  AddEnvironmentConstraintsToMap(State);
+
+  // Collecting information about nonloc::ConcreteInt and loc::ConcreteInt
+  // values from the store.
+  GetAllConcreteValues Callback(ConstraintMap, State);
+  State->getStateManager().getStoreManager().iterBindings(State->getStore(),
+                                                          Callback);
+
+  // Collecting constraints from constraint managers.
+  AddConstraintManagerConstraintsToMap(State);
+}
+
+static void printSourceRange(llvm::raw_ostream &Out, const SourceRange &R,
+                             const SourceManager &SM) {
+  Out << "start: ";
+  R.getBegin().print(Out, SM);
+  Out << " end: ";
+  R.getEnd().print(Out, SM);
+}
+
+void ConstraintInfo::addFIDs(FIDMap &FIDs, SmallVectorImpl<FileID> &V,
+                             const SourceManager &SM) const {
+  assert(std::find_if(ConstraintMap.begin(), ConstraintMap.end(),
+                      [](const ConstraintMapTy::value_type &Pair) {
+                        return Pair.first.isInvalid();
+                      }) == ConstraintMap.end() &&
+         "ConstraintInfo stored an entry with an invalid SourceRange!");
+  for (const ConstraintMapTy::value_type &Pair : ConstraintMap) {
+    AddFID(FIDs, V, SM, Pair.first.getBegin());
+    AddFID(FIDs, V, SM, Pair.first.getEnd());
+  }
+}
+
+void ConstraintInfo::printPlist(llvm::raw_ostream &Out, const SourceManager &SM,
+                                const markup::FIDMap &FM,
+                                unsigned indent) const {
+  Indent(Out, indent) << "<dict>\n";
+  ++indent;
+
+  Indent(Out, indent) << "<key>kind</key><string>constraintinfo</string>\n";
+  Indent(Out, indent) << "<key>entries</key>\n";
+  Indent(Out, indent) << "<array>\n";
+  ++indent;
+
+  for (const ConstraintMapTy::value_type &Pair : ConstraintMap) {
+    Indent(Out, indent) << "<dict>\n";
+    ++indent;
+
+    const ConstraintEntry &Entry = Pair.second;
+
+    Indent(Out, indent) << "<key>location</key>\n";
+    EmitRange(Out, SM, {Pair.first, false}, FM, indent);
+
+    Indent(Out, indent) << "<key>statement</key>\n";
+    Indent(Out, indent);
+    EmitString(Out, Entry.Statement) << '\n';
+
+    Indent(Out, indent) << "<key>symbol</key>\n";
+    Indent(Out, indent);
+    EmitString(Out, Entry.Symbol) << '\n';
+
+    Indent(Out, indent) << "<key>constraint</key>\n";
+    Indent(Out, indent);
+    EmitString(Out, Entry.Constraint) << '\n';
+
+    --indent;
+    Indent(Out, indent) << "</dict>\n";
+  }
+
+  --indent;
+  Indent(Out, indent) << "</array>\n";
+
+  --indent;
+  Indent(Out, indent) << "</dict>\n";
+}
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void
+ConstraintInfo::dumpToStream(llvm::raw_ostream &Out,
+                             const SourceManager &SM) const {
+  Out << "ConstraintInfo entries:\n";
+  for (const ConstraintMapTy::value_type &Pair : ConstraintMap) {
+    Out << '\n';
+
+    const ConstraintEntry &Entry = Pair.second;
+    printSourceRange(Out, Pair.first, SM);
+    const std::string NewLine = "\n  ";
+    Out << NewLine << "statement: " << Entry.Statement << NewLine
+        << "symbol: " << Entry.Symbol << NewLine
+        << "constraint: " << Entry.Constraint << '\n';
+  }
+}
+#endif
+
+//===----------------------------------------------------------------------===//
+// StateInfo methods.
+//===----------------------------------------------------------------------===//
+
+void StateInfo::addStateInfoFromState(ProgramStateRef State) {
+  llvm::raw_string_ostream OS(StateDump);
+  State->print(OS, "\n", "\n");
+}
+
+void StateInfo::printPlist(llvm::raw_ostream &Out, const SourceManager &SM,
+                           const markup::FIDMap &FM, unsigned indent) const {
+  Indent(Out, indent) << "<dict>\n";
+  ++indent;
+
+  Indent(Out, indent) << "<key>kind</key><string>stateinfo</string>\n";
+  Indent(Out, indent) << "<key>entry</key>\n";
+  Indent(Out, indent);
+  EmitString(Out, StateDump) << '\n';
+
+  --indent;
+  Indent(Out, indent) << "</dict>\n";
+}
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void StateInfo::dumpToStream(llvm::raw_ostream &Out,
+                                              const SourceManager &SM) const {
+  Out << "StateInfo entries:\n";
+  Out << StateDump << '\n';
+}
+#endif

--- a/lib/StaticAnalyzer/Core/InternalInfoImplementations.h
+++ b/lib/StaticAnalyzer/Core/InternalInfoImplementations.h
@@ -1,0 +1,108 @@
+//===- InternalInfoImplementations.h ----------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the InternalInfo interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_STATICANALYZER_CORE_INTERNALINFOIMPLEMENTATIONS_H
+#define LLVM_CLANG_STATICANALYZER_CORE_INTERNALINFOIMPLEMENTATIONS_H
+
+#include "clang/StaticAnalyzer/Core/BugReporter/InternalInfo.h"
+
+namespace clang {
+namespace ento {
+
+class ConstraintInfo : public InternalInfo {
+public:
+  struct ConstraintEntry {
+    std::string Statement;
+    std::string Symbol;
+    std::string Constraint;
+
+    ConstraintEntry() = default;
+
+    /// Overwrites all empty string fields from \p Other.
+    void update(const ConstraintEntry &Other);
+  };
+
+  struct SourceRangeComparator {
+    bool operator()(const SourceRange &LHS, const SourceRange &RHS) const {
+      if (LHS.getBegin() == RHS.getBegin()) {
+        return LHS.getEnd() < RHS.getEnd();
+      } else {
+        return LHS.getBegin() < RHS.getBegin();
+      }
+    }
+  };
+
+  using ConstraintMapTy =
+      std::map<SourceRange, ConstraintEntry, SourceRangeComparator>;
+
+private:
+  ConstraintMapTy ConstraintMap;
+
+public:
+  ConstraintInfo() : InternalInfo(Constraint) {}
+
+  static constexpr Kind getStaticKind() { return Constraint; }
+
+  void copyContents(const ConstraintInfo &Other);
+
+  void addConstraintsFromState(ProgramStateRef State);
+
+  virtual void addFIDs(markup::FIDMap &FIDs, SmallVectorImpl<FileID> &V,
+                       const SourceManager &SM) const override;
+
+  virtual void printPlist(llvm::raw_ostream &Out, const SourceManager &SM,
+                          const markup::FIDMap &FM,
+                          unsigned Indent) const override;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD
+  virtual void dumpToStream(llvm::raw_ostream &Out,
+                            const SourceManager &SM) const override;
+#endif
+
+private:
+  void AddEnvironmentConstraintsToMap(ProgramStateRef State);
+
+  void AddConstraintManagerConstraintsToMap(ProgramStateRef State);
+};
+
+class StateInfo : public InternalInfo {
+  std::string StateDump;
+
+public:
+  StateInfo() : InternalInfo(State) {}
+
+  static constexpr Kind getStaticKind() { return State; }
+
+  void addStateInfoFromState(ProgramStateRef State);
+
+  bool isEmpty() { return StateDump.empty(); }
+
+  virtual void addFIDs(markup::FIDMap &FIDs, SmallVectorImpl<FileID> &V,
+                       const SourceManager &SM) const override {}
+
+  virtual void printPlist(llvm::raw_ostream &Out, const SourceManager &SM,
+                          const markup::FIDMap &FM,
+                          unsigned Indent) const override;
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD
+  virtual void dumpToStream(llvm::raw_ostream &Out,
+                            const SourceManager &SM) const override;
+#endif
+};
+
+} // namespace ento
+} // namespace clang
+
+#endif // LLVM_CLANG_STATICANALYZER_CORE_BUGREPORTER_INTERNALINFO_H

--- a/lib/StaticAnalyzer/Core/PathDiagnostic.cpp
+++ b/lib/StaticAnalyzer/Core/PathDiagnostic.cpp
@@ -29,6 +29,7 @@
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
+#include "clang/StaticAnalyzer/Core/BugReporter/InternalInfo.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/AnalysisManager.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/SVals.h"
@@ -44,6 +45,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include "InternalInfoImplementations.h"
 #include <cassert>
 #include <cstring>
 #include <memory>
@@ -123,6 +125,38 @@ void PathPieces::flattenTo(PathPieces &Primary, PathPieces &Current,
       break;
     }
   }
+}
+
+
+PathPieces::iterator PathPieces::erase(PathPieces::const_iterator Pos) {
+  using PathPiecesImpl = std::list<std::shared_ptr<PathDiagnosticPiece>>;
+
+  if (Pos == end())
+    return PathPiecesImpl::erase(Pos);
+
+  // By the end of this function, PrevMap will be destructed.
+  InternalInfoMap &PrevMap = (*Pos)->InternalInfos;
+  if (!PrevMap.isEnabled<ConstraintInfo>())
+    return PathPiecesImpl::erase(Pos);
+
+  // By the end of this function, the element referenced by PrevPos will be
+  // destructed.
+  auto PrevPos = Pos++;
+  if (Pos == end())
+    return PathPiecesImpl::erase(PrevPos);
+
+  InternalInfoMap &CurrMap = (*Pos)->InternalInfos;
+
+  // Before we delete PrevPos, we'll pass information from its ConstraintInfo
+  // to the next.
+  // FIXME: We should use copy ctor instead of inserting an empty ConstraintInfo
+  // into the map, but for some reason it crashes.
+  if (!CurrMap.isEnabled<ConstraintInfo>())
+    CurrMap.getOrInsert<ConstraintInfo>();
+
+  CurrMap.get<ConstraintInfo>().copyContents(PrevMap.get<ConstraintInfo>());
+
+  return PathPiecesImpl::erase(PrevPos);
 }
 
 PathDiagnostic::~PathDiagnostic() = default;

--- a/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
+++ b/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
@@ -138,6 +138,10 @@ private:
                             unsigned indent, unsigned depth);
   void ReportNote(raw_ostream &o, const PathDiagnosticNotePiece& P,
                   unsigned indent);
+
+  void ReportConstraintsAsEvent(raw_ostream &o,
+                                const PathDiagnosticPiece& P,
+                                unsigned indent);
 };
 
 } // end of anonymous namespace
@@ -210,12 +214,75 @@ void PlistPrinter::EmitMessage(raw_ostream &o, StringRef Message,
   EmitString(o, Message) << '\n';
 }
 
+static void EmitConstraints(raw_ostream &o,
+                            const SourceManager &SM,
+                            const FIDMap& FM,
+                            const InternalInfoMap &Map,
+                            unsigned indent) {
+  if (Map.empty())
+    return;
+
+  Indent(o, indent) << "<key>internalinfos</key>\n";
+  Indent(o, indent) << "<array>\n";
+  ++indent;
+  for (const auto &Info : Map) {
+    ++indent;
+
+		Info.printPlist(o, SM, FM, indent);
+
+    --indent;
+  }
+  --indent;
+  Indent(o, indent) << "</array>\n";
+}
+
+// TODO: Change this hack to a command line option.
+// Since internal information isn't supported by CodeChecker just yet (duh),
+// we'll convert them to events.
+void PlistPrinter::ReportConstraintsAsEvent(raw_ostream &o,
+                                     const PathDiagnosticPiece& P,
+                                     unsigned indent) {
+  if (P.InternalInfos.empty())
+    return;
+
+  const SourceManager &SM = PP.getSourceManager();
+
+  Indent(o, indent) << "<dict>\n";
+  ++indent;
+
+  Indent(o, indent) << "<key>kind</key><string>event</string>\n";
+
+  // Output the location.
+  FullSourceLoc L = P.getLocation().asLocation();
+
+  Indent(o, indent) << "<key>location</key>\n";
+  EmitLocation(o, SM, L, FM, indent);
+
+  // Output the ranges (if any).
+  ArrayRef<SourceRange> Ranges2 = P.getRanges();
+  EmitRanges(o, Ranges2, indent);
+
+  llvm::SmallString<200> str;
+  llvm::raw_svector_ostream OS(str);
+  OS << ' ';
+  P.InternalInfos.dumpToStream(OS, SM);
+
+  // Output the text.
+  EmitMessage(o, OS.str(), indent);
+
+  // Finish up.
+  --indent;
+  Indent(o, indent); o << "</dict>\n";
+}
+
 void PlistPrinter::ReportControlFlow(raw_ostream &o,
                                      const PathDiagnosticControlFlowPiece& P,
                                      unsigned indent) {
 
   const SourceManager &SM = PP.getSourceManager();
   const LangOptions &LangOpts = PP.getLangOpts();
+
+  ReportConstraintsAsEvent(o, P, indent);
 
   Indent(o, indent) << "<dict>\n";
   ++indent;
@@ -260,6 +327,9 @@ void PlistPrinter::ReportControlFlow(raw_ostream &o,
     EmitString(o, s) << '\n';
   }
 
+  // Output constraints.
+  EmitConstraints(o, SM, FM, P.InternalInfos, indent);
+
   --indent;
   Indent(o, indent) << "</dict>\n";
 }
@@ -269,6 +339,7 @@ void PlistPrinter::ReportEvent(raw_ostream &o, const PathDiagnosticEventPiece& P
                                bool isKeyEvent) {
 
   const SourceManager &SM = PP.getSourceManager();
+  ReportConstraintsAsEvent(o, P, indent);
 
   Indent(o, indent) << "<dict>\n";
   ++indent;
@@ -296,9 +367,13 @@ void PlistPrinter::ReportEvent(raw_ostream &o, const PathDiagnosticEventPiece& P
   // Output the text.
   EmitMessage(o, P.getString(), indent);
 
+  // Output constraints.
+  EmitConstraints(o, SM, FM, P.InternalInfos, indent);
+
   // Finish up.
   --indent;
   Indent(o, indent); o << "</dict>\n";
+
 }
 
 void PlistPrinter::ReportCall(raw_ostream &o, const PathDiagnosticCallPiece &P,
@@ -523,6 +598,7 @@ void PlistDiagnostics::FlushDiagnosticsImpl(
       AddFID(FM, Fids, SM, Range.getBegin());
       AddFID(FM, Fids, SM, Range.getEnd());
     }
+    Piece.InternalInfos.addFIDs(FM, Fids, SM);
   };
 
   for (const PathDiagnostic *D : Diags) {

--- a/test/Analysis/analyzer-config.c
+++ b/test/Analysis/analyzer-config.c
@@ -44,6 +44,8 @@
 // CHECK-NEXT: debug.AnalysisOrder:PreStmtOffsetOfExpr = false
 // CHECK-NEXT: debug.AnalysisOrder:RegionChanges = false
 // CHECK-NEXT: display-ctu-progress = false
+// CHECK-NEXT: dump-constraint-info = false
+// CHECK-NEXT: dump-state-info = false
 // CHECK-NEXT: eagerly-assume = true
 // CHECK-NEXT: elide-constructors = true
 // CHECK-NEXT: expand-macros = false
@@ -87,4 +89,4 @@
 // CHECK-NEXT: unroll-loops = false
 // CHECK-NEXT: widen-loops = false
 // CHECK-NEXT: [stats]
-// CHECK-NEXT: num-entries = 84
+// CHECK-NEXT: num-entries = 86


### PR DESCRIPTION
This PR is a tool to help with the understanding of what the CSA does during analysis, which could make deciding whether a checker's warning was a false positive or not easier, and if it was, it could help the developer understand what went wrong. This is done by storing information during the construction is `PathDiagnosticPiece`s, and dumping them later in the plist file.

One can see these at each point of the bugpath.

The main components of the code is 
1. The abstract class `InternalInfo`, which provides an easy-to-implement interface for storing information from the CSA and dumping them in the plist output
2. The data structure `InternalInfoMap`, to conveniently store `InternalInfo` objects.

There are a number of possible implementations for `InternalInfo`:
* `ConstraintInfo` will store information from `Environment`, `Constraintmanager` and the store for each`PathDiagnosticPiece`
* `StateInfo` will store the `ProgramState` information of a given `ExplodedNode` that was used to generate the `PathDiagnosticPiece`
* `InterestingSymbolInfo` will store symbols marked as interesting.

This PR containts the first two.

One, or multiple of these could be enabled with command line commands, for example `-analyzer-config dump-constraint-info=true`.